### PR TITLE
Added splitting for multi-word phrases returned by Dragon as single words when handling formatters.

### DIFF
--- a/std.py
+++ b/std.py
@@ -74,6 +74,12 @@ def FormatText(m):
             fmt.append(w.word)
     words = [str(s).lower() for s in m.dgndictation[0]._words]
 
+    # Ensure multi-word phrases are single words
+    tmp = []
+    for word in words:
+        tmp.extend(word.split())
+    words = tmp
+
     tmp = []
     spaces = True
     for i, word in enumerate(words):


### PR DESCRIPTION
Addressing [Issue #2](https://github.com/talonvoice/examples/issues/2) 